### PR TITLE
Removed /api from URL routes because backend server now listens on ap…

### DIFF
--- a/backend/app/controller/assignments.js
+++ b/backend/app/controller/assignments.js
@@ -27,7 +27,9 @@ exports.getAssignments = function(req, callback) {
 exports.createAssignment = function(req, callback) {
   var assignment = new Assignment();
   assignment.title    = req.body.title.trim();
-  assignment.dueDate  = new Date(req.body.dueDate);
+
+  // Turn UNIX time in req.body to milliseconds for JS date constructor
+  assignment.dueDate  = new Date(parseInt(req.body.dueDate) * 1000);
   assignment.username = req.params.username;
   if(req.body.class) assignment.class             = req.body.class.trim();
   if(req.body.type) assignment.type               = req.body.type.trim();

--- a/backend/app/models/assignment.js
+++ b/backend/app/models/assignment.js
@@ -1,4 +1,5 @@
 ﻿var mongoose = require('mongoose');
+mongoose.Promise = require('bluebird');
 
 var AssignmentSchema = mongoose.Schema({
     title:          { type: String, required: true },

--- a/backend/app/models/user.js
+++ b/backend/app/models/user.js
@@ -1,5 +1,7 @@
 var mongoose  = require('mongoose'),
     bcrypt    = require('bcrypt-nodejs');
+mongoose.Promise = require('bluebird');
+
 
 // User-id is auto-generated when pushed to mongodb
 var UserSchema = mongoose.Schema({

--- a/backend/app/router_mod.js
+++ b/backend/app/router_mod.js
@@ -15,7 +15,7 @@ module.exports = function(_router) {
   // Middleware
 	router.use((req, res, next) => {
     var ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-    console.log('%s request came in from %s', req.method, ip);
+    console.log('%s: %s request came in from %s', new Date().toISOString(), req.method, ip);
     next();
 	});
 
@@ -92,10 +92,10 @@ module.exports = function(_router) {
     if (!isValidPassword(req.body.password)) {
       return reject(req, res, 'invalid_request_error', 'Your password parameter is invalid');
     }
-    if (!isValidName(req.body.firstName)) {
+    if (req.body.firstName && !isValidName(req.body.firstName)) {
       return reject(req, res, 'invalid_request_error', 'Your firstName parameter is invalid');
     }
-    if (!isValidName(req.body.lastName)) {
+    if (req.body.lastName && !isValidName(req.body.lastName)) {
       return reject(req, res, 'invalid_request_error', 'Your lastName parameter is invalid');
     }
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "bcrypt-nodejs": "~0.0.3",
+    "bluebird": "^3.5.0",
     "body-parser": "latest",
     "cors": " 2.8.1",
     "express": "latest",

--- a/backend/server.js
+++ b/backend/server.js
@@ -12,13 +12,13 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
   extended: true
 }));
-app.use('/api', router);
+app.use('/', router);
 
+mongoose.Promise = require('bluebird');
 mongoose.connect(config.database);
 
 app.listen(PORT, (err) => {
-  if (err) {
-    return console.log('Server connection error', err);
-  }
+  if (err) return console.log('Server connection error', err);
+
   console.log(`Epicenter magic happens on port ${PORT}`);
 });


### PR DESCRIPTION
…i.pyrsuit.com instead of www.pyrsuit.com/api. Installed bluebird promise library because mongoose promise library is deprecated and is 4x slower than es6 native promises or mongoose promises. Added timestamp log in the router middlewar to provide more info when server receives requests. Made firstName and lastName optional properties when creating a user. Fixed a bug when trying to create an assignment that would throw an error because unix timestamp could not be passed into date constructor. The issue has been resolved